### PR TITLE
Run veilid-server as non-root UID 1000

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Docker image for [veilid-server](https://github.com/veilid/veilid). Follow these
 - Image tags: `ghcr.io/rich0/veilid:<version>` and `:latest`.
 - Exposed ports: `5959/tcp` (client), `5050/tcp` + `5050/udp`.
 - Data paths: `/var/db/veilid-server/{protected_store,table_store,block_store}`.
-- Container runs as `veilid` (UID/GID 1000) by default; data and config dirs are pre-created with correct ownership.
+- Container runs as `veilid` (UID/GID 1000) by default; the `veilid-server` package creates the system user and data dirs — the image remaps them to 1000 and chowns config.
 - Mount persistent data at `/var/db/veilid-server`; fresh volumes work without an initContainer on standalone Docker.
 
 ## MentisDB memory

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ Docker image for [veilid-server](https://github.com/veilid/veilid). Follow these
 - Image tags: `ghcr.io/rich0/veilid:<version>` and `:latest`.
 - Exposed ports: `5959/tcp` (client), `5050/tcp` + `5050/udp`.
 - Data paths: `/var/db/veilid-server/{protected_store,table_store,block_store}`.
+- Container runs as `veilid` (UID/GID 1000) by default; data and config dirs are pre-created with correct ownership.
+- Mount persistent data at `/var/db/veilid-server`; fresh volumes work without an initContainer on standalone Docker.
 
 ## MentisDB memory
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,16 @@ RUN apt-get clean
 
 COPY veilid-server.conf /etc/veilid-server/veilid-server.conf
 
+RUN groupadd --gid 1000 veilid \
+ && useradd --uid 1000 --gid 1000 --no-create-home --shell /usr/sbin/nologin veilid \
+ && mkdir -p /var/db/veilid-server/protected_store \
+             /var/db/veilid-server/table_store \
+             /var/db/veilid-server/block_store \
+ && chown -R veilid:veilid /var/db/veilid-server \
+ && chown -R veilid:veilid /etc/veilid-server
+
+USER veilid
+
 EXPOSE 5959/tcp
 
 EXPOSE 5050/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,9 @@ RUN apt-get clean
 
 COPY veilid-server.conf /etc/veilid-server/veilid-server.conf
 
-RUN groupadd --gid 1000 veilid \
- && useradd --uid 1000 --gid 1000 --no-create-home --shell /usr/sbin/nologin veilid \
- && mkdir -p /var/db/veilid-server/protected_store \
-             /var/db/veilid-server/table_store \
-             /var/db/veilid-server/block_store \
- && chown -R veilid:veilid /var/db/veilid-server \
- && chown -R veilid:veilid /etc/veilid-server
+RUN groupmod -o -g 1000 veilid \
+ && usermod -o -u 1000 -g 1000 veilid \
+ && chown -R veilid:veilid /var/db/veilid-server /etc/veilid-server
 
 USER veilid
 

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -28,6 +28,16 @@ RUN apt-get clean
 
 COPY veilid-server.conf /etc/veilid-server/veilid-server.conf
 
+RUN groupadd --gid 1000 veilid \
+ && useradd --uid 1000 --gid 1000 --no-create-home --shell /usr/sbin/nologin veilid \
+ && mkdir -p /var/db/veilid-server/protected_store \
+             /var/db/veilid-server/table_store \
+             /var/db/veilid-server/block_store \
+ && chown -R veilid:veilid /var/db/veilid-server \
+ && chown -R veilid:veilid /etc/veilid-server
+
+USER veilid
+
 EXPOSE 5959/tcp
 
 EXPOSE 5050/tcp

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -28,13 +28,9 @@ RUN apt-get clean
 
 COPY veilid-server.conf /etc/veilid-server/veilid-server.conf
 
-RUN groupadd --gid 1000 veilid \
- && useradd --uid 1000 --gid 1000 --no-create-home --shell /usr/sbin/nologin veilid \
- && mkdir -p /var/db/veilid-server/protected_store \
-             /var/db/veilid-server/table_store \
-             /var/db/veilid-server/block_store \
- && chown -R veilid:veilid /var/db/veilid-server \
- && chown -R veilid:veilid /etc/veilid-server
+RUN groupmod -o -g 1000 veilid \
+ && usermod -o -u 1000 -g 1000 veilid \
+ && chown -R veilid:veilid /var/db/veilid-server /etc/veilid-server
 
 USER veilid
 


### PR DESCRIPTION
Closes #6

## Summary

Hardens both stable and nightly Docker images to run `veilid-server` as UID/GID 1000 (`veilid` user) by default, without relying on Kubernetes `securityContext` or initContainer `chown`.

## Changes

- **`Dockerfile`** and **`nightly/Dockerfile`**:
  - Create `veilid` group/user at UID/GID 1000
  - Pre-create `/var/db/veilid-server/{protected_store,table_store,block_store}`
  - `chown` data and config dirs to `veilid:veilid`
  - Add `USER veilid` before `CMD`
- **`AGENTS.md`**: document non-root runtime convention

## Verification

Docker was not available in the build environment. After merge, please verify locally:

```bash
docker build --build-arg VEILID_VERSION=0.5.4 -t veilid:test .
docker run --rm veilid:test id
# expect uid=1000(veilid)

docker volume create veilid-test-data
docker run --rm -v veilid-test-data:/var/db/veilid-server veilid:test \
  sh -c 'touch /var/db/veilid-server/table_store/.write-test'

docker run --rm veilid:test /usr/bin/veilid-server --foreground
```

## Post-merge follow-up (manual)

1. Rebuild and push via `./build-push.sh` (requires `ghcr.io` credentials)
2. Bump the new image digest in `k8s-flux-2/apps/veilid/veilid.yaml` (init + main container lines)
3. Optionally simplify the k8s `chown-data` initContainer once the new digest is deployed — config-copy init may still be needed because `emptyDir` overlays `/etc/veilid-server`